### PR TITLE
Update `bin/ascii85` to be Ruby 3.2 compatible

### DIFF
--- a/bin/ascii85
+++ b/bin/ascii85
@@ -56,7 +56,7 @@ end
 if @options[:file] == '-'
   @input = $stdin.binmode.read
 else
-  unless File.exists?(@options[:file])
+  unless File.exist?(@options[:file])
     abort "File not found: \"#{@options[:file]}\""
   end
 


### PR DESCRIPTION
Ruby 3.2 removed the deprecated `File.exists?` method in favor of consolidating on File.exist?

This allows the executable to be ran in Ruby 3.2+